### PR TITLE
백준알고리즘 12094번 2048(Hard)

### DIFF
--- a/2171141_추영광/Python/BJ_12094.py
+++ b/2171141_추영광/Python/BJ_12094.py
@@ -1,0 +1,120 @@
+import sys 
+input = sys.stdin.readline
+
+def move(arr, cnt = 0, M = 1):
+    global MaxValue
+    if cnt >= 10 or (MaxValue >= (M * (1 << (10-cnt)))):
+        return max(M, MaxValue)
+    cache = M
+
+    C = [i[:] for i in arr]
+    no_move = True 
+    for x in range(n):
+        add = 0
+        for y in range(1, n):
+            if not C[y][x]: continue
+            if C[y][x] == C[add][x]:
+                C[add][x] *= 2
+                M = max(C[add][x], M)
+                C[y][x] = 0
+                add += 1
+                no_move = False
+            elif C[add][x] == 0:
+                C[add][x] = C[y][x]
+                C[y][x] = 0
+                no_move = False
+            elif add+1 != y:
+                add += 1
+                C[add][x] = C[y][x]
+                C[y][x] = 0
+                no_move = False
+            else:
+                add += 1
+    if not no_move: MaxValue = max(move(C, cnt+1, M), MaxValue, M)
+
+    C = [i[:] for i in arr]
+    no_move = True
+    M = cache
+    for x in range(n):
+        add = n-1
+        for y in range(n-2, -1, -1):
+            if not C[y][x]: continue
+            if C[y][x] == C[add][x]:
+                C[add][x] *= 2
+                M = max(C[add][x], M)
+                C[y][x] = 0
+                add-=1
+                no_move = False
+            elif C[add][x] == 0:
+                C[add][x] = C[y][x]
+                C[y][x] = 0
+                no_move = False
+            elif add-1 != y:
+                add -= 1
+                C[add][x] = C[y][x]
+                C[y][x] = 0
+                no_move = False
+            else:
+                add -= 1
+    if not no_move: MaxValue = max(move(C, cnt+1, M), MaxValue, M)
+
+    C = [i[:] for i in arr]
+    no_move = True
+    M = cache
+    for y in range(n):
+        add = 0
+        for x in range(1, n):
+            if not C[y][x]: continue
+            if C[y][x] == C[y][add]:
+                C[y][add] *= 2
+                M = max(C[y][add], M)
+                C[y][x] = 0
+                add += 1
+                no_move = False
+            elif C[y][add] == 0:
+                C[y][add] = C[y][x]
+                C[y][x] = 0
+                no_move = False
+            elif add+1 != x:
+                add += 1
+                C[y][add] = C[y][x]
+                C[y][x] = 0
+                no_move = False
+            else:
+                add += 1
+    if not no_move: MaxValue = max(move(C, cnt+1, M), MaxValue, M)
+
+    C = [i[:] for i in arr]
+    no_move = True
+    M = cache
+    for y in range(n):
+        add = n-1
+        for x in range(n-2, -1, -1):
+            if not C[y][x]: continue
+            if C[y][x] == C[y][add]:
+                C[y][add] *= 2
+                M = max(C[y][add], M)
+                C[y][x] = 0
+                add-=1
+                no_move = False
+            elif C[y][add] == 0:
+                C[y][add] = C[y][x]
+                C[y][x] = 0
+                no_move = False
+            elif add-1 != x:
+                add -= 1
+                C[y][add] = C[y][x]
+                C[y][x] = 0
+                no_move = False
+            else:
+                add -= 1
+    if not no_move: MaxValue = max(move(C, cnt+1, M), MaxValue, M)
+    return MaxValue
+
+n = int(input())
+arr = [list(map(int, input().split())) for _ in ' '*n]
+MaxValue = 0
+for i in arr:
+    MaxValue = max(MaxValue, max(i))
+move(arr, M = MaxValue)
+print(MaxValue)

--- a/2171141_추영광/Python/BJ_18224.py
+++ b/2171141_추영광/Python/BJ_18224.py
@@ -1,0 +1,73 @@
+import sys 
+from collections import deque
+input = sys.stdin.readline
+ 
+def lowerbound_x(x, y):
+    l = 0; r = len(void_idx_x[y])-1
+    while l < r:
+        m = l + r >> 1
+        if void_idx_x[y][m] >= x: r = m 
+        else: l = m + 1
+    return r
+
+def lowerbound_y(x, y):
+    l = 0; r = len(void_idx_y[x])-1
+    while l < r:
+        m = l + r >> 1
+        if void_idx_y[x][m] >= y: r = m
+        else: l = m+1
+    return r
+
+vec = ((1,0), (-1,0), (0,1), (0,-1))
+def bfs(x, y, t, walk):
+    next_t = t + (walk+1) // m
+    next_m = (walk+1) % m
+    for dx, dy in vec:
+        nx, ny = dx+x, dy+y
+        if not (0 <= nx < n and 0 <= ny < n): continue
+        if not t%2: # 낮
+            if M[ny][nx] or ((1<<(next_t%2+10))|(1<<next_m) in visited[ny][nx]): continue
+            d.append([nx, ny, next_t, next_m])
+            visited[ny][nx].add(1<<(next_t%2+10)|1<<next_m)
+        else:
+            if not M[ny][nx] and not ((1<<(next_t%2+10))|(1<<next_m) in visited[ny][nx]):
+                visited[ny][nx].add(1<<(next_t%2+10)|1<<next_m)
+                d.append([nx, ny, next_t, next_m])
+            elif M[ny][nx]:
+                if dx:
+                    k = lowerbound_x(x, y)
+                    if (dx == -1 and k == 0) or (dx == 1 and k == len(void_idx_x[y])-1): continue
+                    elif dx == -1: k = void_idx_x[y][k-1]
+                    else: k = void_idx_x[y][k+1]
+                    if not ((1<<(next_t%2+10))|(1<<next_m) in visited[ny][k]):
+                        visited[ny][k].add(1<<(next_t%2+10)|1<<next_m)
+                        d.append([k, ny, next_t, next_m])
+                elif dy:
+                    k = lowerbound_y(x, y)
+                    if (dy == -1 and k == 0) or (dy == 1 and k == len(void_idx_y[x])-1): continue
+                    elif dy == -1: k = void_idx_y[x][k-1]
+                    else: k = void_idx_y[x][k+1]
+                    if not ((1<<(next_t%2+10))|(1<<next_m) in visited[k][nx]):
+                        visited[k][nx].add(1<<(next_t%2+10)|1<<next_m)
+                        d.append([nx, k, next_t, next_m])
+
+n, m = map(int, input().split())
+M = list(list(map(int, input().split())) for _ in ' '*n)
+visited = [[set() for _ in ' '*n] for _ in ' '*n]
+
+void_idx_x = [[] for _ in ' '*n]
+void_idx_y = [[] for _ in ' '*n]
+for y, i in enumerate(M):
+    for x, j in enumerate(i):
+        if not j:
+            void_idx_x[y].append(x)
+            void_idx_y[x].append(y)
+
+d = deque([[0, 0, 0, 0]])
+while d:
+    x, y, t, walk = d.popleft()
+    if x == n-1 and y == n-1:
+        print(1+t//2, ('sun','moon')[t%2])
+        break
+    bfs(x, y, t, walk)
+else: print(-1)


### PR DESCRIPTION
2048(Hard)

백트래킹

백트래킹은 쉽게 말하면 완전탐색의 아종으로, 완전탐색 하다가 이거 틀렸네? 하면 바로 다른 루트로 갈아타는 문제 해결 방식입니다.
보통 재귀로 구현이 되며, 재귀의 필수요건인 '중단 조건'을 잘 설정해야 백트래킹의 최대 효율을 볼 수 있습니다.

2048 구현 자체도 꽤 난이도가 높은데 (실제로 구현만 하면 되는 2048 (Easy)도 있습니다.) 여기에 백트래킹을 살짝 첨가한 문제가 2048 (Hard)입니다.

첫 중단 조건 : 10번 움직인 경우
문제에서 대놓고 '10번까지 움직인 경우, 최대값을 출력하라'라고 나와있습니다.

두 번째 중단 조건 : 현재까지 찾아낸 최댓값을 N이라 하고, 현재 T번째 움직임을 탐색 중 일 때, 현재 최댓값이 N/(2^(10-T)) 이하인 경우
예를 들어 현재까지 찾아낸 최댓값이 1024일 때, 9번째의 512 이하는 모두 탐색할 필요가 없습니다. 한 번 움직이면 최댓값은 최대 2배로 오르는데, 9번째에서 512가 최댓값인 경우는 10번째에서 잘 쳐줘야 최댓값이 1024니까요. 답 갱신이 나오지 않는 경우이므로 잘라내도 됩니다.

세 번째 중단 조건 : 한번 움직였으나, 움직임이 없는 경우
이 경우는 현재 탐색중인 경우와 다를게 없으므로 잘라내야합니다.

2048을 구현하고, 위 경우만 잘 잘라낸다면 정답입니다!!를 받을 수 있습니다.
푸느라 한 4시간 썼던거같네요..
같은 부분이 4번 반복되는데, 그 부분은 함수로 만들려다가 실패했고,
move함수의 M과 cnt 자리를 바꾸려했는데 그거 그냥 보기좋게 바꾸려다가 5곳 바꿔야하길래 그냥 뒀습니다. 일단 1회용 코딩인데 굳이 바꿨다가 오류나면 골치아프니까요..

////////////////////////////////////////////////////////////////////////////////
하나 더 올리려했는데 Pull Request 눌렀더니 여기에 바로 합쳐져서 수정해서 쓰겠습니다.
////////////////////////////////////////////////////////////////////////////////

미로에 갇힌 건우

BFS, 이분탐색, 비트마스킹

그래프 풀다보면 나오는 벽 부수고 이동하기가 생각나는 문제입니다.
저는 별로 효율적으로 풀지 못한 편입니다.
한 10시간 넘게 푼거같은데..

BFS문제는 좀 꼬았다 싶은거 보면 대부분 방문여부를 꼬아두었습니다.
달이 차오른다, 가자 (1194)번도 보면 열쇠가 생기면서 방문여부도 동시에 꼬아버렸습니다.

저 같은 경우, 방문체크를 비트마스킹으로 했습니다. 모범답안은 낮에 이동한 걸음 수, 밤에 이동한 걸음 수를 따로 만들어서 처리하는것 같습니다.
m이 10 이하인 점, 저는 걸어다닌 걸음 수 관리를 %m을 계속 하며 관리한다는 점을 이용해 10번째 비트에는 낮을, 11번째 비트에는 밤을 할당하고, 1~9번째에는 걸어다닌 정도를 할당했습니다. 이 둘을 합쳐 방문체크를 하는 방식으로요.

이분탐색은 빈 공간을 찾는데에 썼습니다. 문제에 보면 건너편에 가장 가까운 빈 공간으로 벽을 넘을 수 있다, 이렇게 있는데 '네잎클로버를 찾아서(3089)'처럼 이분탐색으로 그 공간을 찾았습니다.
lowerbound는 arr을 변수로 받으면 하나로 합칠 수 있을 것 같긴 한데 '이미 굴러가는거 건들지 말자!' 라는 마인드로 그냥 합치지 않았습니다..