### PR TITLE
백준알고리즘 9944번 NxM 보드 완주하기

### DIFF
--- a/2171141_추영광/Kotlin/BJ_9944.kt
+++ b/2171141_추영광/Kotlin/BJ_9944.kt
@@ -1,0 +1,59 @@
+import java.io.*
+
+val dxl = intArrayOf(1, -1, 0, 0)
+val dyl = intArrayOf(0, 0, 1, -1)
+var ans = 1000000
+
+fun dfs(x:Int, y:Int, M:Array<String>, n:Int, m:Int, cnt:Int = 0):Int{
+    var blocked = 0
+    for (i in 0..3){
+        val dx = dxl[i]; val dy = dyl[i]
+        val C = M.copyOf()
+        C[y] = StringBuilder(C[y]).also {it.setCharAt(x, '*')}.toString()
+        var nx = dx+x; var ny = dy+y
+        if (!(nx in 0 until m && ny in 0 until n)) {blocked++; continue}
+        if (C[ny][nx] == '*') {blocked++; continue}
+        while (nx in 0 until m && ny in 0 until n && C[ny][nx] == '.'){
+            C[ny] = StringBuilder(C[ny]).also {it.setCharAt(nx, '*')}.toString()
+            nx += dx; ny += dy
+        }
+        ans = minOf(ans, dfs(nx-dx, ny-dy, C, n, m, cnt+1))
+    }
+    var check = 0
+    if (blocked == 4){
+        M.forEachIndexed{ cy, it ->
+            it.forEachIndexed{cx, k->
+                if (k == '*' || (cy == y && cx == x)) check++
+            }
+        }
+        return if (check == n*m) cnt else 1000000
+    }
+    return ans
+}
+
+fun main(){
+    val br = BufferedReader(InputStreamReader(System.`in`))
+    val bw = BufferedWriter(OutputStreamWriter(System.out))
+
+    var tc = 1
+    while (true){
+        val tmp = br.readLine() ?: break
+        val (n, m) = tmp.split(" ").map {it.toInt()}
+        val M = Array<String>(n) {br.readLine()}
+        val testCoor = mutableListOf<IntArray>()
+        M.forEachIndexed{ y, i ->
+            i.forEachIndexed{ x, j ->
+                if (j == '.') testCoor.add(intArrayOf(x, y))
+            }
+        }
+        var res = 1000000; ans = 1000000
+        testCoor.forEach{(x, y) ->
+            res = minOf(dfs(x, y, M, n, m), res)
+        }
+        bw.write("Case $tc: ${if (res==1000000) -1 else res}\n"); tc++
+    }
+
+    br.close()
+    bw.flush()
+    bw.close()
+}


### PR DESCRIPTION
DFS, Back-Tracking

공으로 보드의 모든 칸을 완주하는 코드를 짜는 문제입니다.
DFS로 공이 갈 수 있는 모든 칸을 체크하고, 백트래킹으로 현재 도출된 답과 비교했을 때 cnt가 같거나 높은경우 dfs 시작부터 차단시켰습니다.
맵을 카피하지 말고 visited를 인수로 계속 보냈으면 좀 더 빠른 코드가 될 것 같긴 합니다.